### PR TITLE
Fix/repostatus badge

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,10 @@ Authors@R:
              role = c("aut", "cre"),
              email = "maelle.salmon@yahoo.se",
              comment = c(ORCID = "0000-0002-2815-0399")),
+      person(given = "Daniel", 
+             family = "Possenriede", 
+             role = "ctb", 
+             comment = c(ORCID = "0000-0002-6738-9845")),
       person(given = "rOpenSci",
              role = "fnd",
              comment = "https://ropensci.org/"))

--- a/R/use_repostatus_badge.R
+++ b/R/use_repostatus_badge.R
@@ -25,6 +25,12 @@
 use_repostatus_badge <- function(status){
   # inspired by https://github.com/r-lib/usethis/blob/master/R/badge.R
   # so probably needs proper credit!
+  if(missing(status)) {
+    stop("You need to provide a repostatus.org status.", call. = FALSE)
+  }
+
+  status <- tolower(status)
+
   if(!status %in% rodev::repostatus_badges$status){
     stop("The status you input is not a proper repostatus.org status at least when this package version was released. Please have a look at repostatus_badges") # nolint
   }

--- a/R/use_repostatus_badge.R
+++ b/R/use_repostatus_badge.R
@@ -13,7 +13,7 @@
 #' \item unsupported
 #' \item wip
 #' }
-#' For more details refer to \url{repostatus.org}.
+#' For more details refer to \url{https://www.repostatus.org}.
 #'
 #' @return It will help you add the repostatus.org badge to your README.
 #' @export

--- a/man/use_repostatus_badge.Rd
+++ b/man/use_repostatus_badge.Rd
@@ -27,7 +27,7 @@ Possible statuses are \code{rodev::repostatus_badges$status},
 \item unsupported
 \item wip
 }
-For more details refer to \url{repostatus.org}.
+For more details refer to \url{https://www.repostatus.org}.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-use_repostatus_badge.R
+++ b/tests/testthat/test-use_repostatus_badge.R
@@ -2,7 +2,11 @@ context("test-use_repostatus_badge.R")
 
 test_that("use_repostatus_badge checks whether the status exists", {
   expect_error(use_repostatus_badge("wipp"),
-               "repostatus.org")
+               "not a proper repostatus.org status",
+               fixed = TRUE)
+  expect_error(use_repostatus_badge(),
+               "provide a repostatus.org status",
+               fixed = TRUE)
 })
 
 test_that("use_repostatus_badge doesn't fail", {


### PR DESCRIPTION
This PR fixes the link to the [repostatus.org](https://www.repostatus.org) in the `use_repostatus_badge()` documentation.

It also checks whether the `status` argument is (not) missing in the same function.


``` r
library(rodev)
use_repostatus_badge()
#> Error: You need to provide a repostatus.org status.
```

The `status` can also be provided in uppercase, e.g. like `use_repostatus_badge("WIP")`.

